### PR TITLE
fix: 去掉强改全局时区的语句

### DIFF
--- a/src/Tencent/Signature.php
+++ b/src/Tencent/Signature.php
@@ -10,7 +10,6 @@ class Signature {
     public function __construct($accessKey, $secretKey) {
         $this->accessKey = $accessKey;
         $this->secretKey = $secretKey;
-        date_default_timezone_set("PRC");
     }
     public function __destruct() {
     }


### PR DESCRIPTION
并非所有项目都是使用PRC时区，有些项目可能有自己的时区配置